### PR TITLE
replace normal ASI file with a fifo

### DIFF
--- a/timer/celeste_timer.py
+++ b/timer/celeste_timer.py
@@ -135,8 +135,7 @@ class AutoSplitterInfo:
         fmtstring = struct.Struct('Qii???QI??QIIIxxxxI?i100s')
         while self.live:
             last_tick = time.time()
-            self.fp.seek(0)
-            dat = self.fp.raw.read(fmtstring.size)
+            dat = self.fp.read(fmtstring.size)
             _, self.chapter, self.mode, self.timer_active, \
                 self.chapter_started, self.chapter_complete, \
                 chapter_time, self.chapter_strawberries, \

--- a/timer/celeste_timer.py
+++ b/timer/celeste_timer.py
@@ -134,7 +134,6 @@ class AutoSplitterInfo:
     def update_loop(self):
         fmtstring = struct.Struct('Qii???QI??QIIIxxxxI?i100s')
         while self.live:
-            last_tick = time.time()
             dat = self.fp.read(fmtstring.size)
             _, self.chapter, self.mode, self.timer_active, \
                 self.chapter_started, self.chapter_complete, \
@@ -147,10 +146,6 @@ class AutoSplitterInfo:
             self.chapter_time = chapter_time // 10000
             self.file_time = file_time // 10000
             self.level_name = level_name.split(b'\0')[0].decode()
-
-            timeout = last_tick + 0.001 - time.time()
-            if timeout > 0:
-                time.sleep(timeout)
 
 class Trigger:
     def __init__(self, name, end_trigger):

--- a/tracer/celeste_tracer.c
+++ b/tracer/celeste_tracer.c
@@ -10,6 +10,7 @@
 #include <libgen.h>
 #include <dirent.h>
 #include <sys/fcntl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/ptrace.h>
 #include <sys/wait.h>
@@ -335,7 +336,13 @@ void *dump_info_loop(void *v) {
     const char *filename = m->filename;
 
     sleep(2);
-    int dumpfd = open(filename, O_RDWR | O_CREAT, 0644);
+    unlink(filename);
+    int fifo = mkfifo(filename, 0644);
+    if (fifo < 0) {
+        perror("could not create fifo");
+        exit(1);
+    }
+    int dumpfd = open(filename, O_RDWR);
     if (dumpfd < 0) {
         perror("open info dump file");
         exit(1);

--- a/tracer/celeste_tracer.c
+++ b/tracer/celeste_tracer.c
@@ -342,7 +342,7 @@ void *dump_info_loop(void *v) {
         perror("could not create fifo");
         exit(1);
     }
-    int dumpfd = open(filename, O_RDWR);
+    int dumpfd = open(filename, O_RDWR | O_NONBLOCK);
     if (dumpfd < 0) {
         perror("open info dump file");
         exit(1);
@@ -438,7 +438,6 @@ void *dump_info_loop(void *v) {
             info_buf.InCutscene = false;
         }
 
-        lseek(dumpfd, 0, SEEK_SET);
         write(dumpfd, &info_buf, sizeof(DumpInfo));
     }
 }


### PR DESCRIPTION
Currently, `celeste_tracer.c` communicates with route parser programs like `celeste_timer.py` by writing to a file on disk every millisecond. This seems bad. Even though (hopefully! - this may depend on kernel parameters or fstab options) the kernel is caching writes and only actually touching the disk every second or so, this is still quite a lot of unnecessary writing over time. For most disks this probably isn't an issue, but for some it might be, and it doesn't feel like a very clean approach.

With very minimal changes, we can use a FIFO which will behave essentially the same as the file-communication method except that nothing is ever written to disk. I've tested these changes and not noticed any problems (though there could be some corner cases to work out).
