### PR TITLE
add basic support for an intuitive JSON based route format

### DIFF
--- a/timer/json_timer.py
+++ b/timer/json_timer.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import os
+import struct
+import threading
+import time
+import random
+import json
+import mmap
+import enum
+
+# The autosplitter is responsible for reading and parsing a piece of
+#   shared memory from the tracer (see `celeste_tracer.c`). It forks
+#   a thread responsible for scanning this memory on a timer and updates
+#   class attributes. RouteWatcher checks these attributes to see if 
+#   conditions specified in route triggers are met.
+class AutoSplitter:
+    __fmtstring = struct.Struct('8sii???QI??QIIIxxxxI?i100s')
+    def __init__(self, filepath, tickrate=0.001):
+        self._all_attrs = ('__level', 'chapter', 'mode', 'timer_active', 
+                'chapter_started', 'chapter_complete', 'chapter_time', 
+                'chapter_strawberries', 'chapter_cassette', 'chapter_heart', 
+                'file_time', 'file_strawberries', 'file_cassettes', 
+                'file_hearts', 'chapter_checkpoints', 'in_cutscene', 
+                'death_count', 'level_name')
+
+        self.__fp = open(filepath, 'rb')
+        self.__shmem = mmap.mmap(self.__fp.fileno(), 
+                                 self.__fmtstring.size, 
+                                 access=mmap.ACCESS_READ)
+        self.__tickrate = tickrate
+
+        self.__thread = threading.Thread(target=self.update_loop)
+        self.__thread.daemon = True
+        self.__thread.start()
+
+    def __del__(self):
+        self.__shmem.close()
+        self.__fp.close()
+
+    @property
+    def state(self):
+        return dict(zip(self._all_attrs, [getattr(self, attr) for attr in self._all_attrs]))
+
+    def update_loop(self):
+        while True:
+            last_tick = time.time()
+            for attr, val in zip(self._all_attrs, self.__fmtstring.unpack(self.__shmem)):
+                setattr(self, attr, val)
+
+            self.chapter_time //= 10000
+            self.file_time //= 10000
+            self.level_name = self.level_name.split(b'\0')[0].decode()
+
+            timeout = last_tick + self.__tickrate - time.time()
+            if timeout > 0:
+                time.sleep(timeout)
+
+class RouteEvent(enum.Enum):
+    START_SPLIT = enum.auto()
+    END_SPLIT = enum.auto()
+    TRIGGER = enum.auto()
+
+# implements a JSON based route format
+# see `anypercent.json` for example syntax
+class JsonRoute():
+    def __init__(self, filepath):
+        with open(filepath) as f:
+            data = json.load(f)
+            self.name = data["name"] # name for the route that should print in header
+            self.time_field = data["time_field"] # route timed with chapter / file time
+            self.reset_trigger = data.get("reset_trigger") # optional
+            self.route = data["pieces"]
+            # contains a list of splits in printing order
+            # [path_to_piece, level, split_name, elapsed_time=None]
+            self.splits = []
+            # contains splits + triggers in run order
+            self.events = []
+            # the parser creates splits + events from the route JSON
+            self.__parse_json_route(self.route, self.splits, self.events)
+    
+    # A recursive route parser for the non-metadata portion of the 
+    #   JSON route format. Returns only error values, `route` and `splits`
+    #   are modified in place. Splits are in natural / printing order.
+    # The `event` list contains all the events in the order they should
+    #   happen in the run. This is used by the watcher to run through linearly.
+    #   There is an event for both the start and end of a split.
+    def __parse_json_route(self, route, splits, events, split_path="", split_counter=0, level=0):
+        for piece in route:
+            if piece["type"] == "split":
+                # used to make things easy for users only
+                # e.g. we print it in PB file for easy editing
+                split_name = piece["name"]
+                path_to_piece = split_path + split_name
+                
+                # the 4th element is reserved for the elapsed time
+                splits.append([path_to_piece, level, split_name, None])
+
+                # when we encounter a split for the first time, we start
+                # a timer for the split, so add a start_split event
+                piece["split"] = split_counter
+                events.append((RouteEvent.START_SPLIT, split_counter))
+
+                # we need to keep track of the counter because the same split
+                # will need to be ended after we finish recursion
+                split_at_current_depth = split_counter
+                split_counter += 1
+
+                # the recursive step
+                if "pieces" in piece:
+                    split_counter = self.__parse_json_route(piece["pieces"], splits, events, 
+                            path_to_piece + "->", split_counter, level+1)
+
+                # finally, end the split we started above
+                events.append((RouteEvent.END_SPLIT, split_at_current_depth))
+
+            elif piece["type"] == "trigger":
+                events.append((RouteEvent.TRIGGER, piece["trigger"]))
+
+        # the return value is needed when recursing because integers don't impl copy
+        if level != 0:
+            return split_counter
+        return None
+
+# The core livesplit class: walks a route tree waiting for triggers to fire
+# updating splits as it goes, calling out to a print function every `timeout`
+#
+# Implementation note: because we scan only every 0.01s (by default), it's 
+# very important that splits never have triggers as siblings in the JSON. They
+# can take enough time that we miss the starting frame of the split. Without
+# sibling triggers, splits will start automatically when the previous split
+# ends (or when the file is created), so we never miss it. The file timer
+# freezes when the chapter ends, so we *never* miss the ending frame anyway.
+# Presumably it doesn't matter if we miss a checkpoint split by a frame.
+# FIXME: Consider enforcing this in the JSON parser.
+class RouteWatcher():
+    def __init__(self, route, asi, printer, timeout=0.01):
+        self.route = route
+        self.asi = asi
+        self.callback = printer.print
+        self.timeout = timeout
+        # every split that is currently being timed
+        # FIXME: this is small, but maybe still faster to use a set()?
+        self.activesplits = []
+        # contains the asi start time for every started split
+        self.splittime = {}
+        self.needsreset = False
+
+    # A simple utility function to wait for a trigger to fire
+    # FIXME: add some checks for handling keyboard input
+    # FIXME: using `eval` here might be slow(?) and also means that the user
+    # needs to trust the province of their route.json files. Could be improved.
+    def triggerwait(self, trigger):
+        asi = self.asi
+        while not eval(trigger):
+            time.sleep(self.timeout)
+            self.callback(self.asi, self.route, self.activesplits, self.splittime)
+            # Should this only run every 0.1 or something?
+            if eval(self.route.reset_trigger):
+                self.needsreset = True
+                return
+
+    def reset(self):
+        self.needsreset = False
+        self.splittime = {}
+        self.activesplits = []
+        for split in self.route.splits:
+            split[3] = None
+
+    # Watch the list of events, pausing at triggers until the condition is met
+    # Calls the print callback every `timeout` seconds
+    # FIXME: implement this with an index instead of a loop so that we can impl undo
+    def watch(self):
+        for event in self.route.events:
+            if event[0] == RouteEvent.START_SPLIT:
+                self.activesplits.append(event[1])
+                self.splittime[event[1]] = self.asi.file_time
+            elif event[0] == RouteEvent.END_SPLIT:
+                # split[3] stores the elapsed time for completed splits
+                time_elapsed = self.asi.file_time - self.splittime[event[1]]
+                self.route.splits[event[1]][3] = time_elapsed
+                self.activesplits.remove(event[1])
+            elif event[0] == RouteEvent.TRIGGER:
+                self.triggerwait(event[1])
+                if self.needsreset:
+                    self.reset()
+                    self.watch()
+                    return
+
+            self.callback(self.asi, self.route, self.activesplits, self.splittime)
+
+# A wrapper around a simple CSV format to handle PB information
+#
+# format is in the same order as the internal `route.splits` list:
+# [path_to_piece, split_pb_time, pb_time, split_average, split_count]
+#
+# `split_pb_time` is the best time for that split, `pb_time` means
+# the split achieved with the PB for the overall route
+class PersonalBest():
+    def __init__(self, filepath, route):
+        self.filepath = filepath
+        # route is required because splits file doesn't contain enough
+        # information to reconstruct the route
+        self.route = route
+        self.splits = []
+        try:
+            with open(self.filepath, newline="") as f:
+                reader = csv.reader(f)
+                for line in reader:
+                    self.splits.append([line[0], float(line[1]), float(line[2]), 
+                                       float(line[3]), int(line[4])])
+        except FileNotFoundError:
+            pass
+        self.generate_cached_values()
+
+    # cache various splits for easy access from printers and so on
+    def generate_cached_values(self):
+        self.split_pbs = [x[1] for x in self.splits]
+        self.pb_splits = [x[2] for x in self.splits]
+        self.average_splits = [x[3] for x in self.splits]
+        
+        # these will be zero if the PB file doesn't exist yet
+        # important to check truthiness when using
+        self.pb = sum(self.pb_splits)
+
+        # important: only include top level splits in sum
+        self.sum_split_pbs = 0
+        self.sum_average_splits = 0
+        for i in range(len(self.splits)):
+            if self.route.splits[i][1] == 0:
+                self.sum_split_pbs += self.split_pbs[i]
+                self.sum_average_splits += self.average_splits[i]
+
+    # rewrites the PB file with the latest data after a run
+    def update(self, new_splits):
+        # if the PB file is empty, we make a new one
+        if self.pb == 0:
+            self.make_new_pb_file(new_splits)
+            return
+
+        # otherwise compare with existing PB times
+        total_time = sum([x[3] for x in new_splits])
+        for i, newsplit in enumerate(new_splits):
+            # update split PB if improved
+            if newsplit[1] < self.splits[i][1]:
+                self.splits[i][1] = newsplit[3]
+            # update PB splits if overall PB
+            if total_time < self.pb:
+                self.splits[i][2] = newsplit[3]
+            # update average splits (unconditionally)
+            self.splits[i][3] = ((self.splits[i][3] * self.splits[i][4] + newsplit[3]) /
+                                 (self.splits[i][4] + 1))
+            # update count (used to calculate averages)
+            self.splits[i][4] += 1
+
+        # write to file
+        with open(self.filepath, "w", newline="") as f:
+            writer = csv.writer(f)
+            for row in self.splits:
+                writer.writerow(row)
+        
+        # update cached values
+        self.generate_cached_values()
+
+    # make a new PB file from scratch
+    # times for each split are the same since we only have one run
+    def make_new_pb_file(self, new_splits):
+        with open(self.filepath, "w", newline="") as f:
+            writer = csv.writer(f)
+            for row in new_splits:
+                writer.writerow([row[0], row[3], row[3], row[3], 1])
+
+
+# The default implementation of a splits printer; allows comparing with a PB 
+#   file, see `PersonalBest` for implementation.
+# Different implementations of this class are possible, e.g. some kind of GUI
+class SplitsPrinter():
+    def __init__(self, pb, compare_pb=False, compare_splits=True, compare_average=False):
+        self.pb = pb
+        self.compare_pb = compare_pb
+        self.compare_splits = compare_splits
+        self.compare_average = compare_average
+        
+        # handle case where pb file is empty
+        if self.pb.pb == 0:
+            self.compare_pb = False
+            self.compare_splits = False
+            self.compare_average = False
+
+    def get_hms_from_msecs(self, msecs):
+        secs = msecs / 1000
+        mins = int(secs) // 60
+        secs %= 60
+        hrs = mins // 60
+        mins %= 60
+        if hrs > 0:
+            return f"{hrs}:{mins:02}:{secs:06.3f}"
+        elif mins > 0:
+            return f"{mins}:{secs:06.3f}"
+        return f"{secs:.3f}"
+
+    def print(self, asi, route, activesplits, splittime):
+        # this magical string resets the terminal
+        print("\x1b\x5b\x48\x1b\x5b\x4a", end="")
+
+        # this value is prepended to each additional indendation level
+        padding = "  "
+
+        # split[1] is the indentation, split[2] is the split name
+        max_padding = len(padding) * max([x[1] for x in route.splits])
+        max_name_len = max(max([len(x[2]) for x in route.splits]), len(route.name))
+        max_name_len += max_padding
+
+        # generate header
+        header_text = "Split".ljust(max_name_len)
+        header_text +=     "        Time"
+        if self.compare_pb:
+            header_text += "          PB"
+        if self.compare_splits:
+            header_text += "      Splits"
+        if self.compare_average:
+            header_text += "     Average"
+        print(header_text)
+        print("-" * len(header_text))
+
+        for i, split in enumerate(route.splits):
+            split_padding = padding * split[1]
+            fmt_time = ""
+            if i in activesplits:
+                fmt_time = self.get_hms_from_msecs(asi.file_time - splittime[i])
+            elif split[3]:
+                fmt_time = self.get_hms_from_msecs(split[3])
+            line = f"{(split_padding + split[2]).ljust(max_name_len)} {fmt_time.rjust(11)}"
+            if self.compare_pb:
+                fmt_time = self.get_hms_from_msecs(self.pb.pb_splits[i])
+                line += f" {fmt_time.rjust(11)}"
+            if self.compare_splits:
+                fmt_time = self.get_hms_from_msecs(self.pb.split_pbs[i])
+                line += f" {fmt_time.rjust(11)}"
+            if self.compare_average:
+                fmt_time = self.get_hms_from_msecs(self.pb.average_splits[i])
+                line += f" {fmt_time.rjust(11)}"
+            print(line)
+        
+        # footer containing the time for the whole file
+        fmt_time = self.get_hms_from_msecs(asi.file_time)
+        line = f"{route.name.ljust(max_name_len)} {fmt_time.rjust(11)}"
+        if self.compare_pb:
+            fmt_time = self.get_hms_from_msecs(self.pb.pb)
+            line += f" {fmt_time.rjust(11)}"
+        if self.compare_splits:
+            fmt_time = self.get_hms_from_msecs(self.pb.sum_split_pbs)
+            line += f" {fmt_time.rjust(11)}"
+        if self.compare_average:
+            fmt_time = self.get_hms_from_msecs(self.pb.sum_average_splits)
+            line += f" {fmt_time.rjust(11)}"
+        print("-" * len(header_text))
+        print(line)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="A simple Celeste timer with a JSON route format.")
+    parser.add_argument("--asi", default="/dev/shm/autosplitterinfo",
+                        help="path to the auto splitter file created by the tracer")
+    parser.add_argument("--pb", help="path to a custom PB file for the route", default=None)
+    parser.add_argument("route", help="path to your route.json file")
+    args = parser.parse_args()
+
+    if not args.pb:
+        if args.route[-5:] == ".json":
+            args.pb = args.route[:-5] + ".pb"
+        else:
+            args.pb = args.route + ".pb"
+
+    # wait until the tracer is started if necessary
+    if not os.path.exists(args.asi):
+        print('waiting for', args.asi, '...')
+        while not os.path.exists(args.asi):
+            time.sleep(1)
+
+    asi = AutoSplitter(args.asi)
+    route = JsonRoute(args.route)
+    pb = PersonalBest(args.pb, route)
+    printer = SplitsPrinter(pb)
+    watcher = RouteWatcher(route, asi, printer)
+    # FIXME: this should probably keep listening for the reset trigger on completion
+    watcher.watch()
+    pb.update(route.splits)
+
+if __name__ == '__main__':
+    main()

--- a/timer/json_timer.py
+++ b/timer/json_timer.py
@@ -13,72 +13,108 @@ import time
 # The autosplitter is responsible for reading and parsing a piece of
 #   shared memory from the tracer (see `celeste_tracer.c`). It forks
 #   a thread responsible for scanning this memory on a timer and updates
-#   class attributes. RouteWatcher checks these attributes to see if
+#   a dict at `self`. RouteWatcher checks these values to see if
 #   conditions specified in route triggers are met.
-class AutoSplitter:
-    __fmtstring = struct.Struct('8sii???QI??QIIIxxxxI?i100s')
-    def __init__(self, filepath, tickrate=0.001):
-        self._all_attrs = ('__level', 'chapter', 'mode', 'timer_active',
-                'chapter_started', 'chapter_complete', 'chapter_time',
-                'chapter_strawberries', 'chapter_cassette', 'chapter_heart',
-                'file_time', 'file_strawberries', 'file_cassettes',
-                'file_hearts', 'chapter_checkpoints', 'in_cutscene',
-                'death_count', 'level_name')
+class AutoSplitter(dict):
+    # these keys (and the associated Struct) correspond exactly to the binary
+    # format exported by the tracer; order is significant!
+    _keys = (
+        '__level', 'chapter', 'mode', 'timer_active', 'chapter_started',
+        'chapter_complete', '_chapter_time', 'chapter_strawberries',
+        'chapter_cassette', 'chapter_heart', '_file_time',
+        'file_strawberries','file_cassettes', 'file_hearts',
+        'chapter_checkpoints', 'in_cutscene', 'death_count', '_level_name'
+    )
+    __asikeyfmt = struct.Struct('8sii???QI??QIIIxxxxI?i100s')
 
+    # These are the autosplitter values as accessed externally to this class.
+    # Some internal keys (__key) aren't intended for public use; keys prefixed
+    # with _ are available without the prefix in a modified (more useful) form
+    _extras = ("menu",)
+    public_keys = tuple(k.lstrip('_') for k in _keys + _extras if k[:2] != '__')
+
+    def __init__(self, filepath, tickrate=0.001):
         # using mmap should be faster as it avoids overhead from calling read
         self.__fp = open(filepath, 'rb')
         self.__shmem = mmap.mmap(self.__fp.fileno(),
-                                 self.__fmtstring.size,
+                                 self.__asikeyfmt.size,
                                  access=mmap.ACCESS_READ)
 
         self.__tickrate = tickrate
-        self.__thread = threading.Thread(target=self.update_loop)
+        self.__thread = threading.Thread(target=self._update_loop)
         self.__thread.daemon = True
         self.__thread.start()
+
+    @property
+    def chapter_time(self):
+        return self.get('_chapter_time', 0) // 10000
+
+    @property
+    def file_time(self):
+        return self.get('_file_time', 0) // 10000
+
+    @property
+    def level_name(self):
+        return self['_level_name'].partition(b'\0')[0].decode()
+
+    # additional convenience property detects chapter selection screen
+    @property
+    def menu(self):
+        return self['chapter'] == -1
+
+    # overrides dict method to allow access to `chapter_time` and friends
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            return super().__getattribute__(key)
 
     def __del__(self):
         self.__shmem.close()
         self.__fp.close()
 
-    # returns a dict with the total state of the auto splitter encapsulated
-    # avoid using this except for debugging, it's probably slow
-    @property
-    def state(self):
-        return dict(zip(self._all_attrs, [getattr(self, attr) for attr in self._all_attrs]))
-
-    def update_loop(self):
+    def _update_loop(self):
         while True:
             last_tick = time.time()
-            for attr, val in zip(self._all_attrs, self.__fmtstring.unpack(self.__shmem)):
-                setattr(self, attr, val)
-
-            # is it okay to mutate these?
-            self.chapter_time //= 10000
-            self.file_time //= 10000
-            self.level_name = self.level_name.split(b'\0')[0].decode()
+            for key, val in zip(self._keys, self.__asikeyfmt.unpack(self.__shmem)):
+                self[key] = val
 
             timeout = last_tick + self.__tickrate - time.time()
             if timeout > 0:
                 time.sleep(timeout)
 
 
-# We need a nice verbose way to refer to event types
-class EventType(enum.Enum):
+# An Event is a Split or Trigger in a linear playthrough of a route.
+class Event():
+    # flags indicating the type of event
     START_SPLIT = enum.auto()
     END_SPLIT = enum.auto()
     TRIGGER = enum.auto()
+    def __init__(self, ev_type, name=""):
+        self.name = name
+        self.action = ev_type
 
-# both Splits and Triggers are really types of events, but the same
-# event can occur multiple times with a different type, so the Event
-# class wraps this and contains a reference under the `event` attribte.
-class Event():
-    def __init__(self, ev_obj, ev_type):
-        self.event = ev_obj
-        self.type = ev_type
+    def __repr__(self):
+        return self.name
+
+# classes for unified handling of events
+class Trigger(Event):
+    def __init__(self, t_dict, name):
+        self.requirements = t_dict
+        super().__init__(Event.TRIGGER, name)
+
+class StartSplit(Event):
+    def __init__(self, split):
+        self.split = split
+        super().__init__(Event.START_SPLIT, split.path_to_piece)
+
+class EndSplit(Event):
+    def __init__(self, split):
+        self.split = split
+        super().__init__(Event.END_SPLIT, split.path_to_piece)
 
 # The Split class uniquely refers to a split as defined in a Route file
-# and should be passed wherever needed. The same split can occur multiple
-# times (e.g. with different properties) as an Event.
+# and should be passed wherever needed.
 class Split():
     def __init__(self, path_to_piece, name, level=0):
         self.name = name
@@ -103,29 +139,25 @@ class Split():
         # Indicate whether a split is marked as complete or not
         self.active = False
 
-# Dumb implementation just to allow wrapping with Event, but we should make it
-# more extensive in the future, e.g. by moving away from the `eval` based triggers.
-class Trigger():
-    def __init__(self, trigger):
-        self.trigger = trigger
-
-
 # implements a JSON based route format
 # see `anypercent.json` for example syntax
 class JsonRoute():
-    def __init__(self, filepath):
+    def __init__(self, filepath, allow_eval):
+        self.allow_eval = allow_eval
         with open(filepath) as f:
             data = json.load(f)
-            self.name = data["name"] # name for the route that should print in header
-            self.time_field = data["time_field"] # route timed with chapter / file time
-            self.reset_trigger = data.get("reset_trigger") # optional
-            self.route = data["pieces"]
+            self.name = data['name'] # name for the route that should print in header
+            self.time_field = data['time_field'] # route timed with chapter / file time
+            if not self.time_field in ('chapter_time', 'file_time'):
+                raise ValueError('JSON time field must be "chapter_time" or "file_time"')
+            self.reset_trigger = data.get('reset_trigger') # optional
+            self.route = data['splits']
             # contains a list of splits in printing order
             self.splits = []
             # contains splits + triggers in run order
             self.events = []
             # the parser creates splits + events from the route JSON
-            self.__parse_json_route(self.route, self.splits, self.events)
+            self.__parse_json_route(self.route)
 
     # A recursive route parser for the non-metadata portion of the
     #   JSON route format. Returns only error values, `route` and `splits`
@@ -133,41 +165,54 @@ class JsonRoute():
     # The `event` list contains all the events in the order they should
     #   happen in the run. This is used by the watcher to run through linearly.
     #   There is an event for both the start and end of a split.
-    def __parse_json_route(self, route, splits, events, split_path="", level=0):
+    def __parse_json_route(self, route, split_path='', level=0):
         for piece in route:
-            if piece["type"] == "split":
-                # used to make things easy for users only
-                # e.g. we print it in PB file for easy editing
-                path_to_piece = split_path + piece["name"]
-
-                split = Split(
-                        path_to_piece = path_to_piece,
-                        name = piece["name"],
-                        level = level
+            # The route format cannot have splits with sibling triggers.
+            if 'splits' in piece and 'triggers' in piece:
+                raise AssertionError(''
+                    'Splits in your route file should never have triggers as siblings.\n'
+                    'If they do, you can have "missing" time between events.\n'
+                    'If you are sure you know what you\'re doing, you can remove this check.'
                 )
 
-                splits.append(split)
-                split_event = Event(split, EventType.START_SPLIT)
-                events.append(split_event)
+            # used to make things easy for users only
+            # e.g. we print it in PB file for easy editing
+            path_to_piece = split_path + piece['name']
 
-                # the recursive step
-                if "pieces" in piece:
-                    self.__parse_json_route(
-                            route = piece["pieces"],
-                            splits = splits,
-                            events = events,
-                            split_path = path_to_piece + "->",
-                            level = level + 1
-                    )
+            split = Split(
+                path_to_piece = path_to_piece,
+                name = piece['name'],
+                level = level
+            )
 
-                # finally, end the split we started above
-                split_event_end = Event(split, EventType.END_SPLIT)
-                events.append(split_event_end)
+            self.splits.append(split)
+            split_event = StartSplit(split)
+            self.events.append(split_event)
 
-            elif piece["type"] == "trigger":
-                trigger = Trigger(piece["trigger"])
-                trigger_event = Event(trigger, EventType.TRIGGER)
-                events.append(trigger_event)
+            # the recursive step
+            if 'splits' in piece:
+                self.__parse_json_route(
+                    route = piece['splits'],
+                    split_path = path_to_piece + '->',
+                    level = level + 1
+                )
+
+            if 'triggers' in piece:
+                triggers = piece['triggers']
+                for i, trigger in enumerate(triggers):
+                    t_name = f"{split_path}trigger{i+1}"
+                    if 'eval' in trigger and not self.allow_eval:
+                        raise ValueError('Route file used eval, not allowed.')
+                    # sanity checking
+                    for key in trigger:
+                        if not key in AutoSplitter.public_keys and not key == 'eval':
+                            raise ValueError(f'Invalid trigger "{key}" in {t_name}')
+                    trigger_event = Trigger(trigger, name=t_name)
+                    self.events.append(trigger_event)
+
+            # finally, end the split we started above
+            split_event_end = EndSplit(split)
+            self.events.append(split_event_end)
 
 # The core livesplit class: walks a route tree waiting for triggers to fire
 # updating splits as it goes, calling out to a print function every `timeout`
@@ -179,7 +224,6 @@ class JsonRoute():
 # ends (or when the file is created), so we never miss it. The file timer
 # freezes when the chapter ends, so we *never* miss the ending frame anyway.
 # Presumably it doesn't matter if we miss a checkpoint split by a frame.
-# FIXME: Consider enforcing this in the JSON parser.
 class RouteWatcher():
     def __init__(self, route, asi, printer, timeout=0.01):
         self.route = route
@@ -189,19 +233,40 @@ class RouteWatcher():
         self.needsreset = False
         self.started = False
 
+    # a function that sleeps, calls print, and then checks whether a
+    # route reset condition is fulfilled. Reset may not contain eval.
+    def __wait(self):
+        time.sleep(self.timeout)
+        self.callback(self)
+        # Should this only run every 0.1 or something?
+        if self.started and self.route.reset_trigger:
+            for key, val in self.route.reset_trigger.items():
+                if not self.asi[key] == val:
+                    return
+            self.needsreset = True
+
     # A simple utility function to wait for a trigger to fire
     # FIXME: add some checks for handling keyboard input
-    # FIXME: using `eval` here might be slow(?) and also means that the user
-    # needs to trust the province of their route.json files. Could be improved.
     def triggerwait(self, trigger):
         asi = self.asi # do not delete: can be referenced by `eval`
-        while not eval(trigger):
-            time.sleep(self.timeout)
-            self.callback(self.asi)
-            # Should this only run every 0.1 or something?
-            if self.started and self.route.reset_trigger and eval(self.route.reset_trigger):
-                self.needsreset = True
-                return
+        complete = False
+        while not complete:
+            complete = True
+            for key, val in trigger.items():
+                if key == 'type':
+                    continue
+                elif key == 'eval':
+                    if not eval(val):
+                        complete = False
+                        break
+                else:
+                    if asi[key] != val:
+                        complete = False
+                        break
+            if not complete:
+                self.__wait()
+                if self.needsreset:
+                    return
 
     def reset(self):
         self.started = False
@@ -211,26 +276,36 @@ class RouteWatcher():
             split.start_time = None
             split.active = False
 
+    @property
+    def time(self):
+        if self.route.time_field == 'chapter_time':
+            return self.asi['chapter_time']
+        return self.asi['file_time']
+
     # Watch the list of events, pausing at triggers until the condition is met
     # Calls the print callback every `timeout` seconds
     # returns True if event list is completed, false if returning for other reason
     def watch(self):
+        # normally we indicate that we have started (making reset available) only after
+        # seeing the first trigger, but if the timer is started too late, we might miss
+        # the trigger and be left hanging indefinitely
+        if self.time != 0:
+            self.started = True
         try:
             for event in self.route.events:
-                if event.type == EventType.START_SPLIT:
-                    event.event.active = True
-                    event.event.start_time = self.asi.file_time
-                elif event.type == EventType.END_SPLIT:
-                    time_elapsed = self.asi.file_time - event.event.start_time
-                    event.event.elapsed_time = time_elapsed
-                    event.event.active = False
-                elif event.type == EventType.TRIGGER:
-                    self.triggerwait(event.event.trigger)
+                if event.action == Event.START_SPLIT:
+                    event.split.active = True
+                    event.split.start_time = self.time
+                elif event.action == Event.END_SPLIT:
+                    time_elapsed = self.time - event.split.start_time
+                    event.split.elapsed_time = time_elapsed
+                    event.split.active = False
+                elif event.action == Event.TRIGGER:
+                    self.triggerwait(event.requirements)
                     self.started = True
                     if self.needsreset:
                         return False
-                self.callback(self.asi)
-                # only set `started` after the first event fires, prevents repeated resetting
+                self.callback(self)
         except KeyboardInterrupt:
             return False
 
@@ -251,7 +326,7 @@ class PersonalBest():
         self.route = route
         self.splits = []
         try:
-            with open(self.filepath, newline="") as f:
+            with open(self.filepath, newline='') as f:
                 reader = csv.reader(f)
                 for line in reader:
                     self.splits.append([
@@ -310,7 +385,7 @@ class PersonalBest():
                 self.splits[i][4] += 1
 
         # write to file
-        with open(self.filepath, "w", newline="") as f:
+        with open(self.filepath, 'w', newline='') as f:
             writer = csv.writer(f)
             for row in self.splits:
                 writer.writerow(row)
@@ -324,7 +399,7 @@ class PersonalBest():
         # don't save initial splits if route hasn't been completed
         if None in [sp.elapsed_time for sp in new_splits]:
             return
-        with open(self.filepath, "w", newline="") as f:
+        with open(self.filepath, 'w', newline='') as f:
             writer = csv.writer(f)
             for split in new_splits:
                 writer.writerow([
@@ -335,6 +410,10 @@ class PersonalBest():
                         1
                 ])
 
+# for debugging, an easy way to print nothing
+class DummyPrinter():
+    def print(self, arg):
+        return
 
 # The default implementation of a splits printer; allows comparing with a PB
 #   file, see `PersonalBest` for implementation.
@@ -342,7 +421,7 @@ class PersonalBest():
 # Note that instances of this class are route specific because they require a
 # PB instance, which wraps a route specific PB file.
 class SplitsPrinter():
-    def __init__(self, pb, compare_pb=False, compare_splits=True, compare_average=False):
+    def __init__(self, pb, compare_pb, compare_splits, compare_average):
         self.pb = pb
         self.route = pb.route
         self.compare_pb = compare_pb
@@ -350,7 +429,7 @@ class SplitsPrinter():
         self.compare_average = compare_average
 
         # this value is prepended to each additional indendation level
-        self.padding = "  "
+        self.padding = '  '
 
         # calculate the largest space that can be occupied by name + padding
         max_padding = len(self.padding) * max([sp.level for sp in pb.route.splits])
@@ -359,14 +438,14 @@ class SplitsPrinter():
         self.max_name_len += max_padding
 
         # generate header
-        self.header_text = "Split".ljust(self.max_name_len)
-        self.header_text +=     "        Time"
+        self.header_text = 'Split'.ljust(self.max_name_len)
+        self.header_text +=     '        Time'
         if self.compare_pb:
-            self.header_text += "          PB"
+            self.header_text += '          PB'
         if self.compare_splits:
-            self.header_text += "      Splits"
+            self.header_text += '      Splits'
         if self.compare_average:
-            self.header_text += "     Average"
+            self.header_text += '     Average'
 
         # handle case where pb file is empty
         if self.pb.pb == 0:
@@ -381,72 +460,82 @@ class SplitsPrinter():
         hrs = mins // 60
         mins %= 60
         if hrs > 0:
-            return f"{hrs}:{mins:02}:{secs:06.3f}"
+            return f'{hrs}:{mins:02}:{secs:06.3f}'
         if mins > 0:
-            return f"{mins}:{secs:06.3f}"
-        return f"{secs:.3f}"
+            return f'{mins}:{secs:06.3f}'
+        return f'{secs:.3f}'
 
-    def print(self, asi):
+    # routewatcher is implementation defined by RouteWatcher. See that class
+    # for properties available to the printer; it is guaranteed to provide
+    # the properties `route` (the Route object for that watcher) and `time`
+    # (the current ASI time - either chapter or file - used by the route).
+    def print(self, routewatcher):
         # this magical string resets the terminal
-        print("\x1b\x5b\x48\x1b\x5b\x4a", end="")
+        print('\x1b\x5b\x48\x1b\x5b\x4a', end='')
 
         # print header (pre-generated)
         print(self.header_text)
-        print("-" * len(self.header_text))
+        print('-' * len(self.header_text))
 
-        for i, split in enumerate(self.route.splits):
+        for i, split in enumerate(routewatcher.route.splits):
             split_padding = self.padding * split.level
             # either the split is currently active, finished, or never active
-            fmt_time = ""
+            fmt_time = ''
             if split.active:
-                fmt_time = self.get_hms_from_msecs(asi.file_time - split.start_time)
+                fmt_time = self.get_hms_from_msecs(routewatcher.time - split.start_time)
             elif split.elapsed_time:
                 fmt_time = self.get_hms_from_msecs(split.elapsed_time)
-            line = f"{(split_padding + split.name).ljust(self.max_name_len)} {fmt_time.rjust(11)}"
+            line = f'{(split_padding + split.name).ljust(self.max_name_len)} {fmt_time.rjust(11)}'
             if self.compare_pb:
                 fmt_time = self.get_hms_from_msecs(self.pb.pb_splits[i])
-                line += f" {fmt_time.rjust(11)}"
+                line += f' {fmt_time.rjust(11)}'
             if self.compare_splits:
                 fmt_time = self.get_hms_from_msecs(self.pb.split_pbs[i])
-                line += f" {fmt_time.rjust(11)}"
+                line += f' {fmt_time.rjust(11)}'
             if self.compare_average:
                 fmt_time = self.get_hms_from_msecs(self.pb.average_splits[i])
-                line += f" {fmt_time.rjust(11)}"
+                line += f' {fmt_time.rjust(11)}'
             print(line)
 
         # footer containing the time for the whole file
-        fmt_time = self.get_hms_from_msecs(asi.file_time)
-        line = f"{self.route.name.ljust(self.max_name_len)} {fmt_time.rjust(11)}"
+        fmt_time = self.get_hms_from_msecs(routewatcher.time)
+        line = f'{self.route.name.ljust(self.max_name_len)} {fmt_time.rjust(11)}'
         if self.compare_pb:
             fmt_time = self.get_hms_from_msecs(self.pb.pb)
-            line += f" {fmt_time.rjust(11)}"
+            line += f' {fmt_time.rjust(11)}'
         if self.compare_splits:
             fmt_time = self.get_hms_from_msecs(self.pb.sum_split_pbs)
-            line += f" {fmt_time.rjust(11)}"
+            line += f' {fmt_time.rjust(11)}'
         if self.compare_average:
             fmt_time = self.get_hms_from_msecs(self.pb.sum_average_splits)
-            line += f" {fmt_time.rjust(11)}"
-        print("-" * len(self.header_text))
+            line += f' {fmt_time.rjust(11)}'
+        print('-' * len(self.header_text))
         print(line)
 
 
 def main():
-    parser = argparse.ArgumentParser(description="A simple Celeste timer with a JSON route format.")
-    parser.add_argument("--asi", default="/dev/shm/autosplitterinfo",
-                        help="path to the auto splitter file created by the tracer")
-    parser.add_argument("--pb-file", help="path to a custom PB file for the route", default=None)
-    parser.add_argument("--pb", help="compare against your PB", action="store_true", default=False)
-    parser.add_argument("--splits", help="compare against your best splits", action="store_true", default=False)
-    parser.add_argument("--average", help="compare against your average time", action="store_true", default=False)
-    parser.add_argument("route", help="path to your route.json file")
+    parser = argparse.ArgumentParser(description='A simple Celeste timer with a JSON route format.')
+    parser.add_argument('--asi', default='/dev/shm/autosplitterinfo',
+                        help='path to the auto splitter file created by the tracer')
+    parser.add_argument('--pb-file', help='path to a custom PB file for the route', default=None)
+    parser.add_argument('--pb', help='compare against your PB', action='store_true', default=False)
+    parser.add_argument('--splits', help='compare against your best splits', action='store_true', default=False)
+    parser.add_argument('--average', help='compare against your average time', action='store_true', default=False)
+    parser.add_argument('--allow-eval', help='allow the route.json file to use eval (warning: insecure and potentially slow)', action='store_true', default=False)
+    parser.add_argument('route', help='path to your route.json file')
     args = parser.parse_args()
 
     # default pb file is just the route path (with .json extension removed) + .pb
     if not args.pb_file:
-        if args.route[-5:] == ".json":
-            args.pb_file = args.route[:-5] + ".pb"
+        if args.route[-5:] == '.json':
+            args.pb_file = args.route[:-5] + '.pb'
         else:
-            args.pb_file = args.route + ".pb"
+            args.pb_file = args.route + '.pb'
+
+    route = JsonRoute(args.route, args.allow_eval)
+    pb = PersonalBest(args.pb_file, route)
+    printer = SplitsPrinter(pb, args.pb, args.splits, args.average)
+    #printer = DummyPrinter()
 
     # wait until the tracer is started if necessary
     if not os.path.exists(args.asi):
@@ -455,9 +544,6 @@ def main():
             time.sleep(1)
 
     asi = AutoSplitter(args.asi)
-    route = JsonRoute(args.route)
-    pb = PersonalBest(args.pb_file, route)
-    printer = SplitsPrinter(pb, args.pb, args.splits, args.average)
     watcher = RouteWatcher(route, asi, printer)
 
     # loop forever; maybe consider putting this behind an option
@@ -465,7 +551,7 @@ def main():
         result = watcher.watch()
         # wait for reset trigger before restarting
         try:
-            watcher.triggerwait("False")
+            watcher.triggerwait({'eval': 'False'})
         except KeyboardInterrupt:
             pb.update(route.splits)
             break

--- a/timer_data/asides_anypercent.json
+++ b/timer_data/asides_anypercent.json
@@ -1,7 +1,7 @@
 {
     "name": "Any%",
     "time_field": "file_time",
-    "reset_trigger": null,
+    "reset_trigger": "asi.chapter == -1 and asi.file_time == 0",
     "level_names": ["Chapter", "Checkpoint"],
     "pieces": [
         {

--- a/timer_data/asides_anypercent.json
+++ b/timer_data/asides_anypercent.json
@@ -420,7 +420,7 @@
                     "pieces": [
                         {
                             "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 5"
+                            "trigger": "asi.chapter_checkpoints == 6"
                         }
                     ]
                 },

--- a/timer_data/asides_anypercent.json
+++ b/timer_data/asides_anypercent.json
@@ -1,0 +1,444 @@
+{
+    "name": "Any%",
+    "time_field": "file_time",
+    "reset_trigger": null,
+    "level_names": ["Chapter", "Checkpoint"],
+    "pieces": [
+        {
+            "type": "split",
+            "name": "Prologue",
+            "pieces": [
+                {
+                    "type": "trigger",
+                    "trigger": "asi.chapter == 0"
+                },
+                {
+                    "type": "trigger",
+                    "trigger": "asi.chapter == 0 and asi.chapter_complete"
+                },
+                {
+                    "type": "trigger",
+                    "trigger": "asi.chapter == -1"
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "City",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 1"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Crossing",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Chasm",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 1 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "Old Site",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 2"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Intervention",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Awake",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 2 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "Resort",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 3"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Huge Mess",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Elevator Shaft",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 3"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Presidential Suite",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 3 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "Ridge",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 4"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Shrine",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Old Trail",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 3"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Cliff Face",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 4 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "Mirror Temple",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 5"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Depths",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Unravelling",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 3"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Search",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 4"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Rescue",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 5 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "Reflection",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 6"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Lake",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Hollows",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 3"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Reflection",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 4"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Rock Bottom",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 5"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "Resolution",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 6 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "split",
+            "name": "Summit",
+            "pieces": [
+                {
+                    "type": "split",
+                    "name": "Start",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 7"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 1"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "500m",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 2"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "1000m",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 3"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "1500m",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 4"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "2000m",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 5"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "2500m",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter_checkpoints == 5"
+                        }
+                    ]
+                },
+                {
+                    "type": "split",
+                    "name": "3000m",
+                    "pieces": [
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == 7 and asi.chapter_complete"
+                        },
+                        {
+                            "type": "trigger",
+                            "trigger": "asi.chapter == -1"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/timer_data/asides_anypercent.json
+++ b/timer_data/asides_anypercent.json
@@ -1,440 +1,362 @@
 {
     "name": "Any%",
     "time_field": "file_time",
-    "reset_trigger": "asi.chapter == -1 and asi.file_time == 0",
+    "reset_trigger": {
+        "chapter": -1,
+        "file_time": 0
+    },
     "level_names": ["Chapter", "Checkpoint"],
-    "pieces": [
+    "splits": [
         {
-            "type": "split",
             "name": "Prologue",
-            "pieces": [
+            "triggers": [
                 {
-                    "type": "trigger",
-                    "trigger": "asi.chapter == 0"
+                    "chapter": 0
                 },
                 {
-                    "type": "trigger",
-                    "trigger": "asi.chapter == 0 and asi.chapter_complete"
+                    "chapter": 0, 
+                    "chapter_complete": true
                 },
                 {
-                    "type": "trigger",
-                    "trigger": "asi.chapter == -1"
+                    "menu": true
                 }
             ]
         },
         {
-            "type": "split",
-            "name": "City",
-            "pieces": [
+            "name": "Forsaken City",
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 1"
+                            "chapter": 1
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Crossing",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Chasm",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 1 and asi.chapter_complete"
+                            "chapter": 1,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }
             ]
         },
         {
-            "type": "split",
             "name": "Old Site",
-            "pieces": [
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 2"
+                            "chapter": 2
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Intervention",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Awake",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 2 and asi.chapter_complete"
+                            "chapter": 2,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }
             ]
         },
         {
-            "type": "split",
-            "name": "Resort",
-            "pieces": [
+            "name": "Celestial Resort",
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 3"
+                            "chapter": 3
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Huge Mess",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Elevator Shaft",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 3"
+                            "chapter_checkpoints": 3
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Presidential Suite",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 3 and asi.chapter_complete"
+                            "chapter": 3,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }
             ]
         },
         {
-            "type": "split",
-            "name": "Ridge",
-            "pieces": [
+            "name": "Golden Ridge",
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 4"
+                            "chapter": 4
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Shrine",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Old Trail",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 3"
+                            "chapter_checkpoints": 3
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Cliff Face",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 4 and asi.chapter_complete"
+                            "chapter": 4,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }
             ]
         },
         {
-            "type": "split",
             "name": "Mirror Temple",
-            "pieces": [
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 5"
+                            "chapter": 5
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Depths",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Unravelling",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 3"
+                            "chapter_checkpoints": 3
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Search",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 4"
+                            "chapter_checkpoints": 4
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Rescue",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 5 and asi.chapter_complete"
+                            "chapter": 5,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }
             ]
         },
         {
-            "type": "split",
             "name": "Reflection",
-            "pieces": [
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 6"
+                            "chapter": 6
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Lake",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Hollows",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 3"
+                            "chapter_checkpoints": 3
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Reflection",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 4"
+                            "chapter_checkpoints": 4
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Rock Bottom",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 5"
+                            "chapter_checkpoints": 5
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "Resolution",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 6 and asi.chapter_complete"
+                            "chapter": 6,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }
             ]
         },
         {
-            "type": "split",
             "name": "Summit",
-            "pieces": [
+            "splits": [
                 {
-                    "type": "split",
                     "name": "Start",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 7"
+                            "chapter": 7
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 1"
+                            "chapter_checkpoints": 1
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "500m",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 2"
+                            "chapter_checkpoints": 2
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "1000m",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 3"
+                            "chapter_checkpoints": 3
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "1500m",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 4"
+                            "chapter_checkpoints": 4
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "2000m",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 5"
+                            "chapter_checkpoints": 5
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "2500m",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter_checkpoints == 6"
+                            "chapter_checkpoints": 6
                         }
                     ]
                 },
                 {
-                    "type": "split",
                     "name": "3000m",
-                    "pieces": [
+                    "triggers": [
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == 7 and asi.chapter_complete"
+                            "chapter": 7,
+                            "chapter_complete": true
                         },
                         {
-                            "type": "trigger",
-                            "trigger": "asi.chapter == -1"
+                            "menu": true
                         }
                     ]
                 }


### PR DESCRIPTION
I mentioned the possibility of adding JSON support to CelesteMagicTimer in a comment on a previous PR. This adds proof of concept support to `celeste_timer.py` by accepting a JSON route in the new format and automatically generating a route that works with the existing code. 

I'm curious if you have any thoughts about the JSON format I came up with. It seems extremely intuitive to me:

1. Splits are listed in the file in the order that they actually appear in the livesplitter.

2. The "level" concept is a built-in natural result of using JSON, instead of using a list with a "level" value. Splits can be nested arbitrarily deep. 

3. All the splits are given in the JSON itself, rather than (awkwardly, IMO) combining the last subsplit of each split with the split itself. No more `split.names = ["City", "Chasm"]` kind of stuff.

4. Because it's just text, it's a much easier format for most users to edit to meet their own needs. It would also be easier for someone to write a route editor designed around the format even if they weren't familiar with the internals of this program.

Again, though, this is just a proof of concept. I think if it seems nice to you and works well it might be worthwhile to write a version of `celeste_timer.py` that makes it the default, and adds support for text based PB files and so on. I think the natural hierarchical syntax *might* allow for a cleaner timer implementation. At least, a version designed around using this JSON format would not have to do the rather ugly recursive conversion that my POC does.

Might also be worth coding something that can avoid using `eval` for common triggers (chapter endings, room entrance, etc etc).