### PR TITLE
refactored make room splits.

### DIFF
--- a/timer/make_room_splits.py
+++ b/timer/make_room_splits.py
@@ -1,39 +1,66 @@
+#!/usr/bin/env python3
+import uuid
 from celeste_timer import *
 
-asi = AutoSplitterInfo()
-
-input("Go to the start of the chapter you want to set up room splits for and press enter: ")
-
-current_room = asi.level_name
-ctx = 'asi.chapter == %d and asi.mode == %d' % (asi.chapter, asi.mode)
-pieces = []
-seen_rooms = {current_room}
-start_trigger = Trigger('start', '%s and asi.chapter_time < 1000' % ctx)
-
-print("Now, please play through the level")
-
-while not asi.chapter_complete:
-    if asi.level_name not in seen_rooms:
-        trigger = Trigger('enter %s' % asi.level_name, 'asi.level_name == "%s" and %s' % (asi.level_name, ctx))
-        split = Split(current_room)
-        current_room = asi.level_name
-
-        pieces.append(trigger)
-        pieces.append(split)
-        seen_rooms.add(current_room)
-    time.sleep(0.05)
-
-trigger = Trigger('done', 'asi.chapter_complete and %s' % ctx)
-split = Split(current_room)
-pieces.append(trigger)
-pieces.append(split)
+class RoomSplitsMaker:
+    def __init__(self) -> None:
+        self.asi = None
+        self.current_room = None
+        self.ctx = None
+        self.pieces = None
+        self.seen_rooms = None
+        self.start_trigger = None
+        
+    def setup_split_maker(self):
+        self.asi = AutoSplitterInfo()
+        self.current_room = self.asi.level_name
+        self.ctx = 'asi.chapter == %d and asi.mode == %d' % (self.asi.chapter, self.asi.mode)
+        self.pieces = []
+        self.seen_rooms = {self.current_room}
+        self.start_trigger = Trigger('start', '%s and asi.chapter_time < 1000' % self.ctx)
 
 
-name = input("Route name: ")
-filename = input("Filename (will go in ../timer_data/<name>.route): ")
+    def wait_for_playthrough(self):
+        while not self.asi.chapter_complete:
+            if self.asi.level_name not in self.seen_rooms:
+                trigger = Trigger('enter %s' % self.asi.level_name, 'asi.level_name == "%s" and %s' % (self.asi.level_name, self.ctx))
+                split = Split(self.current_room)
+                self.current_room = self.asi.level_name
 
-route = Route(name, 'chapter_time', pieces, ['Segment'], start_trigger)
-filepath = '../timer_data/%s.route' % filename
-save_yaml(filepath, route)
+                self.pieces.append(trigger)
+                self.pieces.append(split)
+                self.seen_rooms.add(self.current_room)
+            time.sleep(0.05)
+        trigger = Trigger('done', 'asi.chapter_complete and %s' % self.ctx)
+        split = Split(self.current_room)
+        self.pieces.append(trigger)
+        self.pieces.append(split)
 
-print('saved to %s' % filepath)
+    def save_route(self, file_name=None, route_name=None, customPath=None):
+        if file_name is None:
+            filename = str(uuid.uuid4())
+        else:
+            filename = file_name
+
+        if route_name is None:
+            name = filename
+        else:
+            name = route_name
+            
+        route = Route(name, 'chapter_time', self.pieces, ['Segment'], self.start_trigger)
+        if customPath is None:
+            filepath = '../timer_data/%s.route' % filename
+        else:
+            filepath  = customPath
+            
+        save_yaml(filepath, route)
+        print('saved to %s' % filepath)
+
+if __name__ == '__main__':
+    maker = RoomSplitsMaker()
+    input("Go to the start of the chapter you want to set up room splits for and press enter: ")
+    maker.setup_split_maker()
+    print("Now, please play through the level")
+    maker.wait_for_playthrough()
+    name = input("Route name: ")
+    maker.save_route(route_name=name)

--- a/timer/make_room_splits.py
+++ b/timer/make_room_splits.py
@@ -63,4 +63,5 @@ if __name__ == '__main__':
     print("Now, please play through the level")
     maker.wait_for_playthrough()
     name = input("Route name: ")
-    maker.save_route(route_name=name)
+    filename = ifilename = input("Filename (will go in ../timer_data/<name>.route): ")
+    maker.save_route(route_name=name, file_name=filename)


### PR DESCRIPTION
Not sure if this goes against what you are trying to do. But I am working on a GUI for the tracer + timer. I want to be able to use my own front end with the make_room_splits.py however the existing implementation isn't really conducive to it.

I refactored the script into a class, and add an if name == '__main__' that retains the original functionality. running the script from a terminal should work the same.
The refactor however lets the script be called elsewhere and gives the caller a little more control over the operations by splitting it up into a few methods.

I also added the option for default file names, route names, and filepaths. 